### PR TITLE
Neg sampling

### DIFF
--- a/deepsnap/dataset.py
+++ b/deepsnap/dataset.py
@@ -192,6 +192,12 @@ class GraphDataset(object):
             negative_label_val (int): The value of negative edges generated
                 in link_pred task. User needs to set this variable in the case
                 of tensor backend custom split.
+            negative_sample_weight (str): Method to generate negative edges
+                in link_pred task. If set to None, negative edges are sampled
+                uniformly.
+                If set to {'dest', 'src', 'both'}, negative edges
+                {pointed to, from, between} nodes with large degrees are more
+                likely to be sampled.
             netlib: Graph backend packages, currently support networkx & snapx.
         """
     def __init__(
@@ -209,6 +215,7 @@ class GraphDataset(object):
         resample_disjoint: bool = False,
         resample_disjoint_period: int = 1,
         negative_label_val: int = None,
+        negative_sample_weight: str = None,
         netlib=None
     ):
         if netlib is not None:
@@ -280,6 +287,7 @@ class GraphDataset(object):
         self.resample_disjoint = resample_disjoint
         self.resample_disjoint_period = resample_disjoint_period
         self.negative_label_val = negative_label_val
+        self.negative_sample_weight = negative_sample_weight
 
         # set private parameters
         self._split_types = None
@@ -1290,7 +1298,8 @@ class GraphDataset(object):
                     if self.negative_edges_mode == "random":
                         graph._create_neg_sampling(
                             self.edge_negative_sampling_ratio,
-                            resample=resample_negative_flag
+                            resample=resample_negative_flag,
+                            negative_sample_weight=self.negative_sample_weight
                         )
                     elif self.negative_edges_mode == "custom":
                         graph._custom_create_neg_sampling(

--- a/deepsnap/graph.py
+++ b/deepsnap/graph.py
@@ -2106,15 +2106,13 @@ class Graph(object):
             elif degree_weighted == "dest":
                 rng = flat.reshape(-1, 1) * num_nodes + receivers.reshape(1, -1)
 
-            rng = rng.reshape(-1,)
+            rng = list(rng.reshape(-1,))
 
-        # perm = torch.tensor(random.sample(rng, num_neg_samples_available))
-        perm = torch.from_numpy(np.random.choice(rng, size=num_neg_samples_available, replace=False))
+        perm = torch.tensor(random.sample(rng, num_neg_samples_available))
         mask = torch.from_numpy(np.isin(perm, idx)).to(torch.bool)
         rest = mask.nonzero().view(-1)
         while rest.numel() > 0:  # pragma: no cover
-            # tmp = torch.tensor(random.sample(rng, rest.size(0)))
-            tmp = torch.from_numpy(np.random.choice(rng, size=rest.size(0), replace=False))
+            tmp = torch.tensor(random.sample(rng, rest.size(0)))
             mask = torch.from_numpy(np.isin(tmp, idx)).to(torch.bool)
             perm[rest] = tmp
             rest = rest[mask.nonzero().view(-1)]

--- a/deepsnap/graph.py
+++ b/deepsnap/graph.py
@@ -2057,6 +2057,11 @@ class Graph(object):
 
         :rtype: :class:`torch.LongTensor`
         """
+        if degree_weighted not in [None, "both", "src", "dest"]:
+            raise ValueError(f"degree_weighted only takes value in "
+                             f"[None, 'both', src', 'dest'], "
+                             f"received value: {degree_weighted}.")
+
         num_neg_samples_available = min(
             num_neg_samples, num_nodes * num_nodes - edge_index.shape[1]
         )

--- a/deepsnap/graph.py
+++ b/deepsnap/graph.py
@@ -2024,7 +2024,8 @@ class Graph(object):
         raise NotImplementedError
 
     @staticmethod
-    def negative_sampling(edge_index, num_nodes: int, num_neg_samples: int):
+    def negative_sampling(edge_index, num_nodes: int, num_neg_samples: int,
+                          degree_weighted: Union[str, None] = None):
         r"""Samples random negative edges of a graph given by :attr:`edge_index`.
 
         Args:
@@ -2037,6 +2038,16 @@ class Graph(object):
                 edge for every positive edge. (default: :obj:`None`)
             force_undirected (bool, optional): If set to :obj:`True`, sampled
                 negative edges will be undirected. (default: :obj:`False`)
+            degree_weighted(str, optional): If set to :obj:`None`, all negative
+                edges have equal probability to be sampled.
+                If set to 'both', edges between nodes with large degrees are
+                more likely to be sampled.
+                If set to 'src', edges from nodes with large degrees are more
+                likely to be sampled.
+                If set to 'dest', edges to nodes with large degrees are more
+                likely tobe sampled.
+                (default: :obj:`None`)
+
 
         :rtype: :class:`torch.LongTensor`
         """
@@ -2053,11 +2064,54 @@ class Graph(object):
         # idx = N * i + j
         idx = (edge_index[0] * num_nodes + edge_index[1]).to("cpu")
 
-        perm = torch.tensor(random.sample(rng, num_neg_samples_available))
+        # TODO: remove this, for debugging purpose  ==========================
+        degree_weighted = "dest"
+        # ====================================================================
+        if degree_weighted is not None:
+            out_deg = node_degree(edge_index, n=num_nodes, mode="out").numpy()
+            in_deg = node_degree(edge_index, n=num_nodes, mode="in").numpy()
+
+            num_influential_nodes = int(np.sum(out_deg + in_deg >= 2))
+
+            # add virtual count such that all nodes might be sampled.
+            out_deg += 1
+            in_deg += 1
+
+            # Ancestral sampling, sample nodes first, then sample edges.
+            # Sample influential senders.
+            senders = np.random.choice(num_nodes,
+                                       size=num_influential_nodes,
+                                       replace=False,
+                                       p=out_deg / np.sum(out_deg))
+            # Sample influential receivers.
+            receivers = np.random.choice(num_nodes,
+                                         size=num_influential_nodes,
+                                         replace=False,
+                                         p=in_deg / np.sum(in_deg))
+
+            # Eventually, we sample num_neg_samples_available negative edges
+            # from rng, which will have num_influential_nodes * k items.
+            k = 100 * num_neg_samples_available // num_influential_nodes
+            # Taking such k, we will sample num_neg_samples_available negative
+            # edges from 100*num_neg_samples_available edges.
+            flat = np.random.choice(num_nodes, size=k, replace=False)
+
+            if degree_weighted == "both":
+                rng = senders.reshape(-1, 1) * num_nodes + receivers.reshape(1, -1)
+            elif degree_weighted == "src":
+                rng = senders.reshape(-1, 1) * num_nodes + flat.reshape(1, -1)
+            elif degree_weighted == "dest":
+                rng = flat.reshape(-1, 1) * num_nodes + receivers.reshape(1, -1)
+
+            rng = rng.reshape(-1,)
+
+        # perm = torch.tensor(random.sample(rng, num_neg_samples_available))
+        perm = torch.from_numpy(np.random.choice(rng, size=num_neg_samples_available, replace=False))
         mask = torch.from_numpy(np.isin(perm, idx)).to(torch.bool)
         rest = mask.nonzero().view(-1)
         while rest.numel() > 0:  # pragma: no cover
-            tmp = torch.tensor(random.sample(rng, rest.size(0)))
+            # tmp = torch.tensor(random.sample(rng, rest.size(0)))
+            tmp = torch.from_numpy(np.random.choice(rng, size=rest.size(0), replace=False))
             mask = torch.from_numpy(np.isin(tmp, idx)).to(torch.bool)
             perm[rest] = tmp
             rest = rest[mask.nonzero().view(-1)]
@@ -2073,3 +2127,16 @@ class Graph(object):
             neg_edge_index = neg_edge_index[:, :num_neg_samples]
 
         return neg_edge_index.to(edge_index.device)
+
+
+def node_degree(edge_index, n=None, mode="in"):
+    if mode == 'in':
+        index = edge_index[0, :]
+    elif mode == 'out':
+        index = edge_index[1, :]
+    else:
+        index = edge_index.flatten()
+    n = edge_index.max() + 1 if n is None else n
+    degree = torch.zeros(n)
+    ones = torch.ones(index.shape[0])
+    return degree.scatter_add_(0, index, ones)


### PR DESCRIPTION
Support weighted negative sampling for link prediction tasks. Add attribute `negative_sample_weight` to `dataset` object. When `negative_sample_weight=None` negative sampling works as before. When `negative_sample_weight = 'dest', 'src', 'both'`,               negative edges `{pointed to, from, between}` nodes with large degrees are more likely to be sampled.