### PR TITLE
fixed syntax error occured while importing ```deepsnap.graph.Graph```

### DIFF
--- a/docs/source/notes/introduction.rst
+++ b/docs/source/notes/introduction.rst
@@ -91,7 +91,7 @@ attribute name :attr:`node_feature`.
     
     import torch
     import networkx as nx
-    rom deepsnap.graph import Graph
+    from deepsnap.graph import Graph
 
     G = nx.Graph()
     G.add_node(0, node_feature=torch.tensor([1,2,3]))


### PR DESCRIPTION
In the Introduction section of the documentation, there is a small syntax error at the place where the creation of graph objects with node features is being demonstrated. It is a small issue, just that it has been written ```rom deepsnap.graph import Graph``` instead of ```from deepsnap.graph import Graph```. It is better to be error-free than having small errors is what I felt and hence corrected it :)